### PR TITLE
shippinglabel 2.3.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# shippinglabel-feedstock
-Utilities for handling packages.
+
+About shippinglabel-feedstock
+=======================
+
+Feedstock license: [BSD-3-Clause](LICENSE)
+
+Home: https://github.com/domdfcoding/shippinglabel
+
+Package license: MIT AND Apache-2.0
+
+Summary: Utilities for handling packages.
+
+
+Current release info
+====================
+
+| Name | Downloads | Version | Platforms |
+| --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-shippinglabel-green.svg)](https://anaconda.org/anaconda/shippinglabel) | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/shippinglabel.svg)](https://anaconda.org/anaconda/shippinglabel) | [![Conda Version](https://img.shields.io/conda/vn/anaconda/shippinglabel.svg)](https://anaconda.org/anaconda/shippinglabel) | [![Conda Platforms](https://img.shields.io/conda/pn/anaconda/shippinglabel.svg)](https://anaconda.org/anaconda/shippinglabel) |
+
+Installing shippinglabel
+==================
+
+Installing `shippinglabel` from the main channel can be achieved by:
+
+```
+conda install shippinglabel
+```
+
+It is possible to list all of the versions of `shippinglabel` available on your platform with `conda`:
+
+```
+conda search shippinglabel
+```

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,4 +5,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/dist-meta-feedstock/pr1/a07f804
   - https://staging.continuum.io/prefect/fs/dom-toml-feedstock/pr1/d7e6d54
   - https://staging.continuum.io/prefect/fs/domdf-python-tools-feedstock/pr2/67eced5
-  - https://staging.continuum.io/prefect/fs/handy-archives-feedstock/pr1/318b367
+  - https://staging.continuum.io/prefect/fs/handy-archives-feedstock/pr1/0ecdbcd

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/dist-meta-feedstock/pr1/a07f804
-  - https://staging.continuum.io/prefect/fs/dom-toml-feedstock/pr1/d7e6d54
-  - https://staging.continuum.io/prefect/fs/domdf-python-tools-feedstock/pr2/67eced5
-  - https://staging.continuum.io/prefect/fs/handy-archives-feedstock/pr1/0ecdbcd

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/dist-meta-feedstock/pr1/a07f804
+  - https://staging.continuum.io/prefect/fs/dom-toml-feedstock/pr1/d7e6d54
+  - https://staging.continuum.io/prefect/fs/domdf-python-tools-feedstock/pr2/67eced5

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/dist-meta-feedstock/pr1/a07f804
   - https://staging.continuum.io/prefect/fs/dom-toml-feedstock/pr1/d7e6d54
   - https://staging.continuum.io/prefect/fs/domdf-python-tools-feedstock/pr2/67eced5
+  - https://staging.continuum.io/prefect/fs/handy-archives-feedstock/pr1/318b367

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "shippinglabel" %}
+{% set version = "2.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/shippinglabel-{{ version }}.tar.gz
+  sha256: 25c0c3194c011c0355dff8f56cc0b31688f693b209f5849d44991d8a2ec91f2f
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<37]
+
+requirements:
+  host:
+    - python
+    - pip
+    - hatchling
+    - hatch-requirements-txt
+  run:
+    - python
+    - dist-meta >=0.1.2
+    - dom-toml >=0.2.2
+    - domdf-python-tools >=3.1.0
+    - packaging >=20.9
+    - typing-extensions >=3.7.4.3
+
+# We can`t enable pytest because conftest uses the coincidence package, which is unavailable on the main channel.
+# The policy states that packages are not specifically built for testing.
+test:
+  imports:
+    - shippinglabel
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+  requires:
+    - pip
+
+about:
+  home: https://github.com/domdfcoding/shippinglabel
+  summary: Utilities for handling packages.
+  license: MIT AND Apache-2.0
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - shippinglabel/_vendor/trove_classifiers/LICENSE
+  description: Utilities for handling packages.
+  doc_url: https://shippinglabel.readthedocs.io
+  dev_url: https://github.com/domdfcoding/shippinglabel
+
+extra:
+  recipe-maintainers:
+    - domdfcoding


### PR DESCRIPTION
shippinglabel 2.3.0 

**Destination channel:** Defaults

### Links

- [PKG-8199]
- dev_url:        https://github.com/domdfcoding/shippinglabel/tree/v2.3.0
- conda_forge:    None
- pypi:           https://pypi.org/project/shippinglabel/2.3.0
- pypi inspector: https://inspector.pypi.io/project/shippinglabel/2.3.0

### Explanation of changes:

- new version number


[PKG-8199]: https://anaconda.atlassian.net/browse/PKG-8199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ