### PR TITLE
shippinglabel 2.3.0 (tests) :snowflake:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,15 +6,20 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/shippinglabel-{{ version }}.tar.gz
-  sha256: 25c0c3194c011c0355dff8f56cc0b31688f693b209f5849d44991d8a2ec91f2f
+  url: https://github.com/domdfcoding/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 17373b3863b9cafa4766d34ccb2e65028b6b2fe949ab820a72a312013c75b9a8
+  patches:
+    - patches/0001-removed-dependencies-from-the-conftest.patch
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<37]
 
 requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -28,16 +33,22 @@ requirements:
     - packaging >=20.9
     - typing-extensions >=3.7.4.3
 
-# We can`t enable pytest because conftest uses the coincidence package, which is unavailable on the main channel.
-# The policy states that packages are not specifically built for testing.
 test:
+  source_files:
+    - tests
   imports:
     - shippinglabel
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    # ModuleNotFoundError: No module named 'apeye'
+    - pytest -v -k "not (test_list_requirements)" tests
   requires:
     - pip
+    - pytest >=6.0.0
+    - coincidence >=0.2.0
+    - consolekit >=1.1.2
+    - requests >=2.25.1
 
 about:
   home: https://github.com/domdfcoding/shippinglabel

--- a/recipe/patches/0001-removed-dependencies-from-the-conftest.patch
+++ b/recipe/patches/0001-removed-dependencies-from-the-conftest.patch
@@ -1,0 +1,46 @@
+From 02f1198fbaf250bf51ab04b6e6914a7759c06727 Mon Sep 17 00:00:00 2001
+From: Andrii Osipov <aosipov@anaconda.com>
+Date: Wed, 21 May 2025 05:03:13 -0700
+Subject: [PATCH] removed dependencies from the conftest
+
+---
+ tests/conftest.py | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 54ce3d4..2f1f70d 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -2,8 +2,8 @@
+ from typing import Callable, Type, TypeVar
+ 
+ # 3rd party
+-from apeye.url import URL
+-from betamax import Betamax  # type: ignore
++# from apeye.url import URL
++# from betamax import Betamax  # type: ignore
+ from domdf_python_tools.paths import PathPlus
+ from packaging.tags import Tag
+ from pytest_regressions.data_regression import RegressionYamlDumper
+@@ -12,8 +12,8 @@ pytest_plugins = ("coincidence", )
+ 
+ _C = TypeVar("_C", bound=Callable)
+ 
+-with Betamax.configure() as config:
+-	config.cassette_library_dir = PathPlus(__file__).parent / "cassettes"
++#with Betamax.configure() as config:
++#	config.cassette_library_dir = PathPlus(__file__).parent / "cassettes"
+ 
+ 
+ def _representer_for(*data_type: Type):  # noqa: MAN002
+@@ -27,6 +27,6 @@ def _representer_for(*data_type: Type):  # noqa: MAN002
+ 	return deco
+ 
+ 
+-@_representer_for(URL, Tag)
++#@_representer_for(URL, Tag)
+ def _represent_sequences(dumper: RegressionYamlDumper, data):  # noqa: MAN001,MAN002
+ 	return dumper.represent_str(str(data))
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
shippinglabel 2.3.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8199]
- dev_url:        https://github.com/domdfcoding/shippinglabel/tree/v2.3.0
- conda_forge:    None
- pypi:           https://pypi.org/project/shippinglabel/2.3.0
- pypi inspector: https://inspector.pypi.io/project/shippinglabel/2.3.0

### Explanation of changes:

- new version number


[PKG-8199]: https://anaconda.atlassian.net/browse/PKG-8199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ